### PR TITLE
Dev/db

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ tracing = "0.1"
 tracing-subscriber = "0.2"
 tracing-futures = "0.2"
 serde = { version = "1.0", features = ["derive"] }
+serde_derive = "1.0"
 serde_json = "1.0"
 reqwest = { version = "0.11", features = ["json"] }
 bcrypt = "0.10"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ branch = "current"
 features = ["yt-dlp", "builtin-queue"]
 
 [dependencies.serenity]
-version = "0.11"
-features = ["client", "standard_framework", "voice", "rustls_backend"]
+version = "0.11.5"
+features = ["client", "standard_framework", "voice", "rustls_backend", "cache", "temp_cache"]
 
 [dependencies.tokio]
 version = "1.27"

--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ follow these instructions to deploy rexmit
 
 3. create an .env file from .env.example
 
+```
+    DEBUG can be 1 for debug or 0 for release
+    DISCORD_TOKEN sourced from discord developer portal
+    DATABASE_URL can be a mongodb connection string or blank
+    
+    the idea is to feature support for mongodb but also to feature support for no database by leaving DATABASE_URL blank
+```
+
 4. build the image
     ```
     docker build -t rexmit .

--- a/README.md
+++ b/README.md
@@ -43,3 +43,16 @@ follow these instructions to deploy rexmit
     ~c
     ~clear
     ```
+
+## database
+
+here is an example of running a document db
+
+
+```
+sudo docker run --name mongo -v ./data/db:/data/db \
+	-p 27017:27017 --restart always \
+	-e MONGO_INITDB_ROOT_USERNAME= \
+	-e MONGO_INITDB_ROOT_PASSWORD= \
+	-d mongo
+```

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,0 +1,11 @@
+use serenity::{prelude::Context, model::prelude::PartialGuild};
+
+pub async fn context_get_guild(ctx: &Context, guild_id: u64) -> Option<PartialGuild> {
+    let partial_guild_result = ctx.http.get_guild(guild_id).await;
+    if partial_guild_result.is_ok() {
+        let partial_guild = partial_guild_result.unwrap();
+        return Some(partial_guild)
+    }
+    println!("context guild not found");
+    return None;
+}

--- a/src/database.rs
+++ b/src/database.rs
@@ -1,0 +1,91 @@
+use std::env;
+
+use mongodb::{
+    Client as MongoClient,
+    Collection, Database, bson::doc
+};
+
+use crate::models::guild::Guild;
+
+pub async fn get_rexmit_database() -> Option<Database> {
+    let database_url: Result<String, env::VarError> = std::env::var("DATABASE_URL");
+    if database_url.is_ok() {
+        let client_result = MongoClient::with_uri_str(database_url.unwrap()).await;
+        if client_result.is_ok() {
+            let client = client_result.unwrap();
+            let database = client.database("rexmit");
+            return Some(database);
+        }
+    }
+    println!("no rexmit database found");
+    return None;
+}
+
+pub async fn get_guild_collection() -> Option<Collection<Guild>> {
+
+    let database_option = get_rexmit_database().await;
+    if database_option.is_some() {
+        let database = database_option.unwrap();
+        let collection: Collection<Guild> = database.collection("guilds");
+        return Some(collection);
+    }
+    println!("no guild collection found");
+    return None;
+}
+
+pub async fn update_guild_queue(guild: serenity::model::prelude::Guild, queue: Vec<String>) {
+    let collection_option = get_guild_collection().await;
+    if collection_option.is_some() {
+        let collection = collection_option.unwrap();
+        let mut guild = Guild::new_from_serenity_guild(Some(guild));
+        guild.queue = queue;
+        
+        let result = collection.find_one_and_update(doc! { "id": &guild.id.to_string() }, doc! { "$set": { "queue": &guild.queue }}, None).await;
+
+        println!("{:?}", result);
+        match &result {
+            Ok(option) => {
+                match &option {
+                    Some(guild) => {
+                        println!("{:?}", guild);
+                    }, 
+                    None => {
+                        let result = collection.insert_one(&guild, None).await;
+                        println!("{:?}", result)
+                    }
+                }
+            },
+            Err(why) => {
+                println!("{}", why)
+            }
+        }
+    }
+}
+
+pub async fn clear_guild_queue(guild: serenity::model::prelude::Guild) {
+    let collection_option = get_guild_collection().await;
+    if collection_option.is_some() {
+        let collection = collection_option.unwrap();
+        let guild = Guild::new_from_serenity_guild(Some(guild));
+        
+        let result = collection.find_one_and_update(doc! { "id": &guild.id.to_string() }, doc! { "$set": { "queue": &guild.queue }}, None).await;
+
+        println!("{:?}", result);
+        match &result {
+            Ok(option) => {
+                match &option {
+                    Some(guild) => {
+                        println!("{:?}", guild);
+                    }, 
+                    None => {
+                        let result = collection.insert_one(&guild, None).await;
+                        println!("{:?}", result)
+                    }
+                }
+            },
+            Err(why) => {
+                println!("{}", why)
+            }
+        }
+    }
+}

--- a/src/database.rs
+++ b/src/database.rs
@@ -4,8 +4,9 @@ use mongodb::{
     Client as MongoClient,
     Collection, Database, bson::doc
 };
+use serenity::prelude::Context;
 
-use crate::models::guild::Guild;
+use crate::{models::guild::Guild, context::context_get_guild};
 
 pub async fn get_rexmit_database() -> Option<Database> {
     let database_url: Result<String, env::VarError> = std::env::var("DATABASE_URL");
@@ -88,4 +89,37 @@ pub async fn clear_guild_queue(guild: serenity::model::prelude::Guild) {
             }
         }
     }
+}
+
+pub async fn set_joined(ctx: &Context, guild_id: u64, joined: bool) -> bool {
+    let collection_option = get_guild_collection().await;
+    if collection_option.is_some() {
+        let collection = collection_option.unwrap();
+        let partial_guild_option = context_get_guild(ctx, guild_id.into()).await;
+        if partial_guild_option.is_some() {
+            let guild = Guild::new_from_serenity_partial_guild(partial_guild_option);
+            let result = collection.find_one_and_update(doc! { "id": &guild_id.to_string() }, doc! { "$set": { "joined": joined }}, None).await;
+    
+            println!("{:?}", result);
+            match &result {
+                Ok(option) => {
+                    match &option {
+                        Some(guild) => {
+                            println!("{:?}", guild);
+                        }, 
+                        None => {
+                            let result = collection.insert_one(&guild, None).await;
+                            println!("{:?}", result);
+                        }
+                    }
+                },
+                Err(why) => {
+                    println!("{}", why);
+                }
+            }
+            return true;
+        }
+    }
+    println!("unable to set joined status");
+    return false;
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -91,6 +91,34 @@ pub async fn clear_guild_queue(guild: serenity::model::prelude::Guild) {
     }
 }
 
+pub async fn pop_guild_queue(guild: serenity::model::prelude::Guild) {
+    let collection_option = get_guild_collection().await;
+    if collection_option.is_some() {
+        let collection = collection_option.unwrap();
+        
+        let result = collection.find_one_and_update(doc! { "id": &guild.id.to_string() }, doc! { "$pop": { "queue": -1 }}, None).await;
+
+        println!("{:?}", result);
+        match &result {
+            Ok(option) => {
+                match &option {
+                    Some(guild) => {
+                        println!("{:?}", guild);
+                    }, 
+                    None => {
+                        let guild = Guild::new_from_serenity_guild(Some(guild));
+                        let result = collection.insert_one(&guild, None).await;
+                        println!("{:?}", result)
+                    }
+                }
+            },
+            Err(why) => {
+                println!("{}", why)
+            }
+        }
+    }
+}
+
 pub async fn set_joined(ctx: &Context, guild_id: u64, joined: bool) -> bool {
     let collection_option = get_guild_collection().await;
     if collection_option.is_some() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod models;
-
+pub mod command;
+pub mod database;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod models;
 pub mod command;
 pub mod database;
+pub mod context;

--- a/src/main.rs
+++ b/src/main.rs
@@ -633,7 +633,6 @@ async fn q(ctx: &Context, msg: &Message, args: Args) -> CommandResult {
 #[command]
 #[only_in(guilds)]
 async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
-    let og_args = args.clone();
     let url = match args.single::<String>() {
         Ok(url) => url,
         Err(_) => {
@@ -659,8 +658,6 @@ async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
 
     let guild = msg.guild(&ctx.cache).unwrap();
     let guild_id = guild.id;
-    let collection_option = get_guild_collection().await;
-
 
     let manager = songbird::get(ctx)
         .await
@@ -693,6 +690,8 @@ async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
                 )
                 .await,
         );
+
+        let collection_option = get_guild_collection().await;
         if collection_option.is_some() {
             let collection = collection_option.unwrap();
             let mut guild = Guild::new_from_serenity_guild(Some(guild));
@@ -724,17 +723,17 @@ async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
     } else {
         check_msg(
             msg.channel_id
-                .say(&ctx.http, "Not in a voice channel to play in")
+                .say(&ctx.http, "not in a voice channel to play in. attempting to join")
                 .await,
         );
-        match join(ctx, msg, og_args.clone()).await {
+        match join(ctx, msg, args.to_owned()).await {
             Ok(result) => {
                 /*check_msg(
                     msg.channel_id
                         .say(&ctx.http, og_args.clone().single::<String>().unwrap())
                         .await,
                 );*/
-                match queue(ctx, msg, og_args.clone()).await {
+                match queue(ctx, msg, args.to_owned()).await {
                     Ok(result) => result,
                     Err(_why) => {
                         check_msg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use std::{
 use mongodb::{
     bson::{doc, }
 };
-use rexmit::{models::{guild::Guild}, database::{get_guild_collection, update_guild_queue, clear_guild_queue, set_joined}};
+use rexmit::{models::{guild::Guild}, database::{get_guild_collection, update_guild_queue, clear_guild_queue, set_joined, pop_guild_queue}};
 use serenity::{
     async_trait,
     client::{Client, Context, EventHandler, Cache},
@@ -262,7 +262,7 @@ impl VoiceEventHandler for TrackEndNotifier {
             for track in track_list.iter() {
                 queue.push(track.1.metadata().source_url.as_ref().unwrap().to_owned());
             }
-            update_guild_queue(self.guild.clone(), queue).await;
+            pop_guild_queue(self.guild.clone()).await;
             check_msg(
                 self.chan_id
                     .say(&self.http, &format!("Track ended: {}", track_list.first().as_ref().unwrap().1.metadata().source_url.as_ref().unwrap()))
@@ -695,7 +695,7 @@ async fn skip(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
                 )
                 .await,
         );
-        
+
     } else {
         check_msg(
             msg.channel_id

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,10 +258,6 @@ struct TrackEndNotifier {
 impl VoiceEventHandler for TrackEndNotifier {
     async fn act(&self, ctx: &EventContext<'_>) -> Option<Event> {
         if let EventContext::Track(track_list) = ctx {
-            let mut queue = vec![];
-            for track in track_list.iter() {
-                queue.push(track.1.metadata().source_url.as_ref().unwrap().to_owned());
-            }
             pop_guild_queue(self.guild.clone()).await;
             check_msg(
                 self.chan_id

--- a/src/main.rs
+++ b/src/main.rs
@@ -262,7 +262,7 @@ async fn join(ctx: &Context, msg: &Message) -> CommandResult {
         let send_cache = ctx.cache.clone();
 
         handle.add_global_event(
-            Event::Periodic(Duration::from_secs(15), None),
+            Event::Periodic(Duration::from_secs(1800), None),
             Periodic {
                 voice_chan_id: connect_to,
                 chan_id,

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,7 @@ async fn get_rexmit_database() -> Option<Database> {
             return Some(database);
         }
     }
+    println!("no rexmit database found");
     return None;
 }
 
@@ -189,6 +190,7 @@ async fn get_guild_collection() -> Option<Collection<Guild>> {
         let collection: Collection<Guild> = database.collection("guilds");
         return Some(collection);
     }
+    println!("no guild collection found");
     return None;
 }
 
@@ -198,6 +200,7 @@ async fn context_get_guild(ctx: &Context, guild_id: u64) -> Option<PartialGuild>
         let partial_guild = partial_guild_result.unwrap();
         return Some(partial_guild)
     }
+    println!("context guild not found");
     return None;
 }
 
@@ -230,6 +233,7 @@ async fn set_joined(ctx: &Context, guild_id: u64, joined: bool) -> bool {
             return true;
         }
     }
+    println!("unable to set joined status");
     return false;
 }
 
@@ -655,14 +659,14 @@ async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
 
     let guild_option = msg.guild(&ctx.cache);
     let guild = guild_option.as_ref().unwrap();
-    let guild_id = guild.id;
+
 
     let manager = songbird::get(ctx)
         .await
         .expect("Songbird Voice client placed in at initialisation.")
         .clone();
 
-    if let Some(handler_lock) = manager.get(guild_id) {
+    if let Some(handler_lock) = manager.get(guild.id) {
         let mut handler = handler_lock.lock().await;
 
         // Here, we use lazy restartable sources to make sure that we don't pay
@@ -698,7 +702,7 @@ async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
                 guild.queue.push(track_handle.metadata().source_url.clone().unwrap())
             }
             
-            let result = collection.find_one_and_update(doc! { "id": &guild_id.to_string() }, doc! { "$set": { "queue": &guild.queue }}, None).await;
+            let result = collection.find_one_and_update(doc! { "id": &guild.id.to_string() }, doc! { "$set": { "queue": &guild.queue }}, None).await;
 
             println!("{:?}", result);
             match &result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,7 +334,7 @@ async fn join(ctx: &Context, msg: &Message) -> CommandResult {
                 },
             );
 
-            set_joined(ctx, guild_id.into(), true).await;
+            //set_joined(ctx, guild_id.into(), true).await;
 
         } else {
             check_msg(
@@ -397,7 +397,7 @@ async fn leave(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
 
             check_msg(msg.channel_id.say(&ctx.http, "Left voice channel").await);
 
-            set_joined(ctx, guild_id.into(), false).await;
+            //set_joined(ctx, guild_id.into(), false).await;
         } else {
             check_msg(msg.reply(ctx, "Not in a voice channel").await);
         }
@@ -714,11 +714,13 @@ async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
                 )
                 .await,
         );
+
         let mut queue = vec![];
         for track_handle in handler.queue().current_queue() {
             queue.push(track_handle.metadata().source_url.clone().unwrap())
         }
-        update_guild_queue(guild, queue).await;
+
+        //update_guild_queue(guild, queue).await;
 
     } else {
         check_msg(
@@ -790,7 +792,8 @@ async fn skip(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
         for track_handle in handler.queue().current_queue() {
             queue.push(track_handle.metadata().source_url.clone().unwrap())
         }
-        update_guild_queue(guild, queue).await;
+
+        //update_guild_queue(guild, queue).await;
     } else {
         check_msg(
             msg.channel_id
@@ -836,7 +839,7 @@ async fn stop(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
         for track_handle in handler.queue().current_queue() {
             queue.push(track_handle.metadata().source_url.clone().unwrap())
         }
-        update_guild_queue(guild, queue).await;
+        //update_guild_queue(guild, queue).await;
         
     } else {
         check_msg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,9 +209,7 @@ async fn set_joined(ctx: &Context, msg: &Message) -> bool {
             let collection = collection_option.unwrap();
             let partial_guild_option = context_get_guild(ctx, guild_id.into()).await;
             if partial_guild_option.is_some() {
-                let partial_guild = partial_guild_option.unwrap();
-                
-                let guild = Guild::new(guild_id.to_string(), partial_guild.clone().name, true);
+                let guild = Guild::new(partial_guild_option);
                 let result = collection.find_one_and_update(doc! { "id": &guild_id.to_string() }, doc! { "$set": { "joined": true }}, None).await;
         
                 println!("{:?}", result);
@@ -689,7 +687,7 @@ async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
         let guild_id = msg.guild_id.unwrap().0;
         let http_guild = ctx.http.get_guild(guild_id).await;
         let partial_guild = http_guild.unwrap();
-        let mut guild = Guild::new(guild_id.to_string(), partial_guild.clone().name, true);
+        let mut guild = Guild::new(Some(partial_guild));
 
         for track_handle in handler.queue().current_queue() {
             guild.queue.push(track_handle.metadata().source_url.clone().unwrap())

--- a/src/main.rs
+++ b/src/main.rs
@@ -574,7 +574,7 @@ async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
             guild.queue.push(track_handle.metadata().source_url.clone().unwrap())
         }
         
-        let result = collection.find_one_and_replace(doc! { "id": &guild_id.to_string() }, &guild, None).await;
+        let result = collection.find_one_and_update(doc! { "id": &guild_id.to_string() }, doc! { "$set": { "queue": &guild.queue }}, None).await;
 
         println!("{:?}", result);
         match &result {

--- a/src/main.rs
+++ b/src/main.rs
@@ -267,7 +267,8 @@ async fn join(ctx: &Context, msg: &Message) -> CommandResult {
                 voice_chan_id: connect_to,
                 chan_id,
                 http: send_http,
-                cache: send_cache
+                cache: send_cache,
+                ctx: ctx.clone()
             },
         );
     } else {
@@ -530,6 +531,7 @@ struct Periodic {
     chan_id: ChannelId,
     http: Arc<Http>,
     cache: Arc<Cache>,
+    ctx: Context,
 }
 
 #[async_trait]
@@ -539,7 +541,30 @@ impl VoiceEventHandler for Periodic {
         match channel.unwrap().guild() {
             Some(guild_channel) => {
                 let members = guild_channel.members(&self.cache).await;
-                println!("{}", members.unwrap().len())
+                println!("{}", members.unwrap().len());
+
+                /*
+                let manager = songbird::get(&self.ctx)
+                    .await
+                    .expect("Songbird Voice client placed in at initialisation.")
+                    .clone();
+
+                let has_handler = manager.get(guild_channel.guild_id).is_some();
+
+                if has_handler {
+                    if let Err(e) = manager.remove(guild_channel.guild_id).await {
+                        check_msg(
+                            self.chan_id
+                                .say(&self.http, format!("Failed: {:?}", e))
+                                .await,
+                        );
+                    }
+
+                    check_msg(self.chan_id.say(&self.http, "Left voice channel").await);
+                } else {
+                    check_msg(self.chan_id.say(&self.http, "Not in a voice channel").await);
+                }
+                */
             },
             None => {
                 println!("{}", "channel was none")

--- a/src/main.rs
+++ b/src/main.rs
@@ -695,13 +695,7 @@ async fn skip(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
                 )
                 .await,
         );
-
-        let mut queue = vec![];
-        for track_handle in handler.queue().current_queue() {
-            queue.push(track_handle.metadata().source_url.clone().unwrap())
-        }
-
-        update_guild_queue(guild, queue).await;
+        
     } else {
         check_msg(
             msg.channel_id
@@ -748,7 +742,7 @@ async fn stop(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
             queue.push(track_handle.metadata().source_url.clone().unwrap())
         }
         
-        update_guild_queue(guild, queue).await;
+        clear_guild_queue(guild).await;
         
     } else {
         check_msg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -541,30 +541,32 @@ impl VoiceEventHandler for Periodic {
         match channel.unwrap().guild() {
             Some(guild_channel) => {
                 let members = guild_channel.members(&self.cache).await;
-                println!("{}", members.unwrap().len());
 
-                /*
-                let manager = songbird::get(&self.ctx)
-                    .await
-                    .expect("Songbird Voice client placed in at initialisation.")
-                    .clone();
+                // please modularize this monstrocity
+                // what i mean by this is create some functions and call the functions instead
+                // we want to utilize DRY (DON'T REPEAT YOURSELF) principles
+                if members.unwrap().len() <= 1 {
+                    let manager = songbird::get(&self.ctx)
+                        .await
+                        .expect("Songbird Voice client placed in at initialisation.")
+                        .clone();
 
-                let has_handler = manager.get(guild_channel.guild_id).is_some();
+                    let has_handler = manager.get(guild_channel.guild_id).is_some();
 
-                if has_handler {
-                    if let Err(e) = manager.remove(guild_channel.guild_id).await {
-                        check_msg(
-                            self.chan_id
-                                .say(&self.http, format!("Failed: {:?}", e))
-                                .await,
-                        );
+                    if has_handler {
+                        if let Err(e) = manager.remove(guild_channel.guild_id).await {
+                            check_msg(
+                                self.chan_id
+                                    .say(&self.http, format!("Failed: {:?}", e))
+                                    .await,
+                            );
+                        }
+
+                        check_msg(self.chan_id.say(&self.http, "Left voice channel").await);
+                    } else {
+                        check_msg(self.chan_id.say(&self.http, "Not in a voice channel").await);
                     }
-
-                    check_msg(self.chan_id.say(&self.http, "Left voice channel").await);
-                } else {
-                    check_msg(self.chan_id.say(&self.http, "Not in a voice channel").await);
                 }
-                */
             },
             None => {
                 println!("{}", "channel was none")

--- a/src/main.rs
+++ b/src/main.rs
@@ -334,7 +334,7 @@ async fn join(ctx: &Context, msg: &Message) -> CommandResult {
                 },
             );
 
-            //set_joined(ctx, guild_id.into(), true).await;
+            set_joined(ctx, guild_id.into(), true).await;
 
         } else {
             check_msg(
@@ -397,7 +397,7 @@ async fn leave(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
 
             check_msg(msg.channel_id.say(&ctx.http, "Left voice channel").await);
 
-            //set_joined(ctx, guild_id.into(), false).await;
+            set_joined(ctx, guild_id.into(), false).await;
         } else {
             check_msg(msg.reply(ctx, "Not in a voice channel").await);
         }
@@ -720,7 +720,7 @@ async fn queue(ctx: &Context, msg: &Message, mut args: Args) -> CommandResult {
             queue.push(track_handle.metadata().source_url.clone().unwrap())
         }
 
-        //update_guild_queue(guild, queue).await;
+        update_guild_queue(guild, queue).await;
 
     } else {
         check_msg(
@@ -793,7 +793,7 @@ async fn skip(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
             queue.push(track_handle.metadata().source_url.clone().unwrap())
         }
 
-        //update_guild_queue(guild, queue).await;
+        update_guild_queue(guild, queue).await;
     } else {
         check_msg(
             msg.channel_id
@@ -839,7 +839,8 @@ async fn stop(ctx: &Context, msg: &Message, _args: Args) -> CommandResult {
         for track_handle in handler.queue().current_queue() {
             queue.push(track_handle.metadata().source_url.clone().unwrap())
         }
-        //update_guild_queue(guild, queue).await;
+        
+        update_guild_queue(guild, queue).await;
         
     } else {
         check_msg(

--- a/src/models/guild.rs
+++ b/src/models/guild.rs
@@ -1,5 +1,3 @@
-use std::collections::VecDeque;
-
 use serde::{Serialize, Deserialize};
 use serenity::model::prelude::PartialGuild;
 

--- a/src/models/guild.rs
+++ b/src/models/guild.rs
@@ -1,6 +1,7 @@
 use std::collections::VecDeque;
 
 use serde::{Serialize, Deserialize};
+use serenity::model::prelude::PartialGuild;
 
 #[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Guild {
@@ -10,10 +11,27 @@ pub struct Guild {
     pub expiration: i64,
     pub joined: bool,
     pub queue: Vec<String>,
+    pub partial_guild_option: Option<PartialGuild>,
 }
 
 impl Guild {
-    pub fn new(id: String, name: String, joined: bool) -> Guild {
-        Guild { id, name, ..Default::default()  }
+    pub fn new(partial_guild_option: Option<PartialGuild>) -> Guild {
+        match &partial_guild_option {
+            Some(partial_guild) => {
+                let id = &partial_guild.id;
+                let name = &partial_guild.name;
+                Guild {
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    partial_guild_option,
+                    ..Default::default() 
+                }
+            },
+            None => { 
+                Guild { 
+                    ..Default::default()
+                }
+            }
+        }
     }
 } 

--- a/src/models/guild.rs
+++ b/src/models/guild.rs
@@ -14,11 +14,30 @@ pub struct Guild {
 }
 
 impl Guild {
-    pub fn new(partial_guild_option: Option<PartialGuild>) -> Guild {
+    pub fn new_from_serenity_partial_guild(partial_guild_option: Option<PartialGuild>) -> Guild {
         match &partial_guild_option {
             Some(partial_guild) => {
                 let id = &partial_guild.id;
                 let name = &partial_guild.name;
+                Guild {
+                    id: id.to_string(),
+                    name: name.to_string(),
+                    ..Default::default() 
+                }
+            },
+            None => { 
+                Guild { 
+                    ..Default::default()
+                }
+            }
+        }
+    }
+
+    pub fn new_from_serenity_guild(guild_option: Option<serenity::model::prelude::Guild>) -> Guild {
+        match &guild_option {
+            Some(guild) => {
+                let id = &guild.id;
+                let name = &guild.name;
                 Guild {
                     id: id.to_string(),
                     name: name.to_string(),

--- a/src/models/guild.rs
+++ b/src/models/guild.rs
@@ -8,11 +8,12 @@ pub struct Guild {
     pub name: String,
     pub subscribed: bool,
     pub expiration: i64,
+    pub joined: bool,
     pub queue: Vec<String>,
 }
 
 impl Guild {
-    pub fn new(id: String, name: String) -> Guild {
-        Guild { id, name, subscribed: false, expiration: 0, ..Default::default()  }
+    pub fn new(id: String, name: String, joined: bool) -> Guild {
+        Guild { id, name, ..Default::default()  }
     }
 } 

--- a/src/models/guild.rs
+++ b/src/models/guild.rs
@@ -3,7 +3,7 @@ use serde::{
     Deserialize
 };
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct Guild {
     pub id: String,
     pub name: String,
@@ -15,4 +15,4 @@ impl Guild {
     pub fn new(id: String, name: String) -> Guild {
         Guild { id, name, subscribed: false, expiration: 0 }
     }
-}
+} 

--- a/src/models/guild.rs
+++ b/src/models/guild.rs
@@ -10,8 +10,7 @@ pub struct Guild {
     pub subscribed: bool,
     pub expiration: i64,
     pub joined: bool,
-    pub queue: Vec<String>,
-    pub partial_guild_option: Option<PartialGuild>,
+    pub queue: Vec<String>
 }
 
 impl Guild {
@@ -23,7 +22,6 @@ impl Guild {
                 Guild {
                     id: id.to_string(),
                     name: name.to_string(),
-                    partial_guild_option,
                     ..Default::default() 
                 }
             },

--- a/src/models/guild.rs
+++ b/src/models/guild.rs
@@ -1,18 +1,18 @@
-use serde::{
-    Serialize,
-    Deserialize
-};
+use std::collections::VecDeque;
 
-#[derive(Serialize, Deserialize, Debug)]
+use serde::{Serialize, Deserialize};
+
+#[derive(Default, Debug, Serialize, Deserialize)]
 pub struct Guild {
     pub id: String,
     pub name: String,
     pub subscribed: bool,
-    pub expiration: i64
+    pub expiration: i64,
+    pub queue: Vec<String>,
 }
 
 impl Guild {
     pub fn new(id: String, name: String) -> Guild {
-        Guild { id, name, subscribed: false, expiration: 0 }
+        Guild { id, name, subscribed: false, expiration: 0, ..Default::default()  }
     }
 } 

--- a/src/models/source.rs
+++ b/src/models/source.rs
@@ -2,7 +2,6 @@ use serde::{
     Serialize,
     Deserialize
 };
-use songbird::input::Input;
 
 #[derive(Serialize, Deserialize)]
 pub struct Source {


### PR DESCRIPTION
oh gooses! here we go again!

rexmit now speaks with mongodb about guilds.
their conversations are rather unappealing however the way is paved for requeueing media upon container restarts.


rexmit would sit in channels all alone. poor rexmit. we gave it some advice that it should leave the channel if no one else is around for a bit.


we thought rexmit deserved to be something other than a single file bundle of commands.
we encouraged rexmit to branch out and become a bit more verbose and modular.


some things i am currently interested in working on:

queue repopulation upon container restart

explore auto-leave resources (ensure they are properly reclaimed and not just pseudo-reclaimed; something about now being able to requeue after an auto-leave)

staying positive and knowing that even though what i am doing may seem small to me, i am on a journey and what i am doing might be huge for someone else

many blessings